### PR TITLE
print exception

### DIFF
--- a/tinkup.py
+++ b/tinkup.py
@@ -257,8 +257,9 @@ class Tink:
                 try:
                     self.serial = serial.Serial(com, baudrate=115200, timeout=None, rtscts=True)
                     print('Opened device at %s' % com)
-                except:
+                except Exception as ex:
                     print('Could not open device at %s' % com)
+                    print('Exception: %s' % ex)
         else:
             print('No RetroTINK devices found')
 


### PR DESCRIPTION
thanks for making this!

on my machine this script fails because i don't have write access on the device by default.

my guess is different os and distro treat this differently? maybe you have write by default on yours?

surfacing the error like this makes it clear to the consumer that they have to change permissions on the device:

```
Could not open device at /dev/ttyUSB0
Exception: [Errno 13] could not open port /dev/ttyUSB0: [Errno 13] Permission denied: '/dev/ttyUSB0'
```

once i changed `/dev/ttyUSB0` to `666` the script runs as expected.